### PR TITLE
Add tslib to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "node": ">=8.5.0"
   },
   "peerDependencies": {
-    "react": "^16.3.0"
+    "react": "^16.3.0",
+    "tslib": "^1.9.3"
   },
   "jsnext:main": "dist/es2015/index.js",
   "module": "dist/es2015/index.js",


### PR DESCRIPTION
react-remove-scroll [depends on tslib since it uses `importHelpers`](https://github.com/theKashey/react-remove-scroll/blob/aa848e678bd57d20fd97b1e42ff62eabd631a237/tsconfig.json#L14), so this ensures that projects depending on react-remove-scroll also have tslib installed.