### PR TITLE
Fix for range input types

### DIFF
--- a/src/handleScroll.ts
+++ b/src/handleScroll.ts
@@ -10,6 +10,9 @@ const elementCouldBeVScrolled = (node: HTMLElement): boolean => {
 
 const elementCouldBeHScrolled = (node: HTMLElement): boolean => {
   const styles = window.getComputedStyle(node);
+  if (node.type === "range") {
+    return true;
+  }
   return (
     styles.overflowX !== 'hidden' && // not-not-scrollable
     !(styles.overflowY === styles.overflowX && styles.overflowX === 'visible') // scrollable


### PR DESCRIPTION
Force inputs with the type range to be always be scrollable on the horizontal plane.

Resolves #33 