### PR TITLE
Fix horizontal scroll for children elements in RTL

### DIFF
--- a/src/handleScroll.ts
+++ b/src/handleScroll.ts
@@ -68,7 +68,8 @@ export const handleScroll = (
   sourceDelta: number,
   noOverscroll: boolean
 ) => {
-  const delta = sourceDelta;
+  const delta = axis === 'h' && document.dir === 'rtl' ? sourceDelta * -1 : sourceDelta;
+
   // find scrollable target
   let target: HTMLElement = event.target as any;
   const targetInLock = endTarget.contains(target);


### PR DESCRIPTION
The delta is inverted in RTL because we are using the scrollLeft to calculate it in the Lib as we can see in [mdn scrollLeft documentation](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollLeft)

`
If the element's direction is rtl (right-to-left), then scrollLeft is 0 when the scrollbar is at its rightmost position (at the start of the scrolled content), and then increasingly negative as you scroll towards the end of the content.
`

Because of that for the calculus to work well in children elements in RTL we need to invert the delta on horizontal scroll.

This PR has the objective of validating that we are in RTL dir and also in horizontal scroll to invert the delta so the calculus work correctly as in LRT. 