### PR TITLE
Fix Attempted import error: '__spreadArray' is not exported from 'tslib'

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "resolutions": {
     "@types/react": "^18.0.0",
-    "tslib": "^2.0.0"
+    "tslib": "^2.1.0"
   },
   "engines": {
     "node": ">=10"
@@ -63,7 +63,7 @@
   "dependencies": {
     "react-remove-scroll-bar": "^2.3.1",
     "react-style-singleton": "^2.2.0",
-    "tslib": "^2.0.0",
+    "tslib": "^2.1.0",
     "use-callback-ref": "^1.3.0",
     "use-sidecar": "^1.1.2"
   },


### PR DESCRIPTION
The current SideEffect.js gets transpiled to import `import { __spreadArray } from "tslib";`
https://unpkg.com/react-remove-scroll@2.5.3/dist/es2015/SideEffect.js

`__spreadArray` was not [added into tslib until 2.1.0](https://github.com/microsoft/tslib/releases/tag/2.1.0)

The current dependency on `"tslib": "^2.0.0",` is resulting in fresh installs installing tslib `2.0.3` and erroring with `Attempted import error: '__spreadArray' is not exported from 'tslib'`