### PR TITLE
Jul 2.5.5

### DIFF
--- a/src/SideEffect.tsx
+++ b/src/SideEffect.tsx
@@ -119,7 +119,9 @@ export function RemoveScrollSideCar(props: IRemoveScrollEffectProps) {
 
     // self event, and should be canceled
     if (sourceEvent && sourceEvent.should) {
-      event.preventDefault();
+      if (event.cancelable) {
+        event.preventDefault();
+      }
 
       return;
     }
@@ -135,7 +137,9 @@ export function RemoveScrollSideCar(props: IRemoveScrollEffectProps) {
         shardNodes.length > 0 ? shouldCancelEvent(event, shardNodes[0]) : !lastProps.current.noIsolation;
 
       if (shouldStop) {
-        event.preventDefault();
+        if (event.cancelable) {
+          event.preventDefault();
+        }
       }
     }
   }, []);

--- a/src/handleScroll.ts
+++ b/src/handleScroll.ts
@@ -1,22 +1,22 @@
 import { Axis } from './types';
 
-const elementCouldBeVScrolled = (node: HTMLElement): boolean => {
+const alwaysContainsScroll = (node: HTMLElement): boolean =>
+  // textarea will always _contain_ scroll inside self. It only can be hidden
+  node.tagName === 'TEXTAREA';
+
+const elementCanBeScrolled = (node: HTMLElement, overflow: 'overflowX' | 'overflowY'): boolean => {
   const styles = window.getComputedStyle(node);
 
   return (
-    styles.overflowY !== 'hidden' && // not-not-scrollable
-    !(styles.overflowY === styles.overflowX && styles.overflowY === 'visible') // scrollable
+    // not-not-scrollable
+    styles[overflow] !== 'hidden' &&
+    // contains scroll inside self
+    !(styles.overflowY === styles.overflowX && !alwaysContainsScroll(node) && styles[overflow] === 'visible')
   );
 };
 
-const elementCouldBeHScrolled = (node: HTMLElement): boolean => {
-  const styles = window.getComputedStyle(node);
-
-  return (
-    styles.overflowX !== 'hidden' && // not-not-scrollable
-    !(styles.overflowY === styles.overflowX && styles.overflowX === 'visible') // scrollable
-  );
-};
+const elementCouldBeVScrolled = (node: HTMLElement): boolean => elementCanBeScrolled(node, 'overflowY');
+const elementCouldBeHScrolled = (node: HTMLElement): boolean => elementCanBeScrolled(node, 'overflowX');
 
 export const locationCouldBeScrolled = (axis: Axis, node: HTMLElement): boolean => {
   let current = node;

--- a/stories/pinch-zoom.stories.tsx
+++ b/stories/pinch-zoom.stories.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import { RemoveScroll } from '../src';
+
+export const PinchZoomNoOverflow = () => (
+  <div className="App">
+    <RemoveScroll allowPinchZoom style={{ height: '5000px' }}>
+      <div
+        style={{
+          border: '1px solid black',
+          padding: '20px',
+          height: '300px',
+          overflow: 'auto',
+          background: 'black',
+          color: 'white',
+        }}
+      >
+        <div>Content</div>
+      </div>
+    </RemoveScroll>
+  </div>
+);
+
+export const PinchZoomOverflow = () => (
+  <div className="App">
+    <RemoveScroll allowPinchZoom style={{ height: '5000px' }}>
+      <div
+        style={{
+          border: '1px solid black',
+          padding: '20px',
+          height: '300px',
+          overflow: 'auto',
+          background: 'black',
+          color: 'white',
+        }}
+      >
+        <div style={{ height: '1000px' }}>Content</div>
+      </div>
+    </RemoveScroll>
+  </div>
+);
+
+export const ControlPinchZoomDisabled = () => (
+  <div className="App">
+    <RemoveScroll style={{ height: '5000px' }}>
+      <div
+        style={{
+          border: '1px solid black',
+          padding: '20px',
+          height: '300px',
+          overflow: 'auto',
+          background: 'black',
+          color: 'white',
+        }}
+      >
+        <div style={{ height: '1000px' }}>Content</div>
+      </div>
+    </RemoveScroll>
+  </div>
+);
+
+export default {
+  title: 'pinch zoom',
+};

--- a/stories/text-area.stories.tsx
+++ b/stories/text-area.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import ReactRemoveScroll from '../src/Combination';
+
+export const TextAreaOverflow = () => (
+  <ReactRemoveScroll>
+    <div>
+      <textarea>{'hello'.repeat(500)}</textarea>
+    </div>
+  </ReactRemoveScroll>
+);
+
+export default {
+  title: 'textarea',
+};


### PR DESCRIPTION
## Fixes
- https://github.com/theKashey/react-remove-scroll/issues/8 - now events are checked for `.canceled` first
- https://github.com/theKashey/react-remove-scroll/issues/74 - text areas seems to have a special behavior and `overflow:visible` is not applicable to them. 