### PR TITLE
Make module point to es2019 build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,8 @@
   "description": "Disables scroll outside of `children` node.",
   "main": "dist/es5/index.js",
   "jsnext:main": "dist/es2015/index.js",
-  "module": "dist/es2015/index.js",
   "types": "dist/es5/index.d.ts",
-  "module:es2019": "dist/es2019/index.js",
+  "module": "dist/es2019/index.js",
   "scripts": {
     "dev": "lib-builder dev",
     "test": "jest",


### PR DESCRIPTION
I think the worlds ready for it, and avoids awkwardness on libraries that depend on this.