### PR TITLE
Fix for elementCanBeScrolled failing if node is not an HTMLElement inside a shadow root

### DIFF
--- a/src/handleScroll.ts
+++ b/src/handleScroll.ts
@@ -1,10 +1,12 @@
-import { Axis } from './types';
+import {Axis} from './types';
 
 const alwaysContainsScroll = (node: HTMLElement): boolean =>
   // textarea will always _contain_ scroll inside self. It only can be hidden
   node.tagName === 'TEXTAREA';
 
 const elementCanBeScrolled = (node: HTMLElement, overflow: 'overflowX' | 'overflowY'): boolean => {
+  if (!(node instanceof HTMLElement)) return false;
+  
   const styles = window.getComputedStyle(node);
 
   return (


### PR DESCRIPTION
Fixes #108.

This PR adds a precautionary check to ensure that `node instanceof HTMLElement`, since it seems that it is possible that `node` might not be an Element. 

I would guess that `handleScroll`'s `event.target as any` can be more than just HTML elements in certain cases inside a Shadow root, so this guards against that.

