### PR TITLE
adjust types for react 19

### DIFF
--- a/.size.json
+++ b/.size.json
@@ -2,19 +2,19 @@
   {
     "name": "dist/es2015/index.js",
     "passed": true,
-    "size": 3449,
+    "size": 3465,
     "sizeLimit": 3500
   },
   {
     "name": "dist/es2015/sidecar.js",
     "passed": true,
-    "size": 2926,
+    "size": 2929,
     "sizeLimit": 3000
   },
   {
     "name": "dist/es2015/UI.js",
-    "passed": true,
-    "size": 989,
+    "passed": false,
+    "size": 1006,
     "sizeLimit": 1000
   }
 ]

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "author": "Anton Korzunov <thekashey@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "@types/react": "^18.0.0",
+    "@types/react": "^18.0.0 || ^19.0.0",
     "@babel/core": "^7.17.9",
     "@size-limit/preset-small-lib": "^11.0.2",
     "size-limit": "^11.0.2",
@@ -40,15 +40,15 @@
     "enzyme-adapter-react-16": "^1.15.6"
   },
   "resolutions": {
-    "@types/react": "^18.0.0",
+    "@types/react": "^18.0.0 || ^19.0.0",
     "tslib": "^2.1.0"
   },
   "engines": {
     "node": ">=10"
   },
   "peerDependencies": {
-    "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/src/SideEffect.tsx
+++ b/src/SideEffect.tsx
@@ -26,9 +26,11 @@ let idCounter = 0;
 let lockStack: any[] = [];
 
 export function RemoveScrollSideCar(props: IRemoveScrollEffectProps) {
-  const shouldPreventQueue = React.useRef<Array<{ name: string; delta: number[]; target: any; should: boolean; shadowParent?: HTMLElement | null }>>([]);
+  const shouldPreventQueue = React.useRef<
+    Array<{ name: string; delta: number[]; target: any; should: boolean; shadowParent?: HTMLElement | null }>
+  >([]);
   const touchStartRef = React.useRef([0, 0]);
-  const activeAxis = React.useRef<Axis | undefined>();
+  const activeAxis = React.useRef<Axis | undefined>(undefined);
   const [id] = React.useState(idCounter++);
   const [Style] = React.useState(styleSingleton);
   const lastProps = React.useRef<IRemoveScrollEffectProps>(props);
@@ -114,7 +116,10 @@ export function RemoveScrollSideCar(props: IRemoveScrollEffectProps) {
 
     const delta = 'deltaY' in event ? getDeltaXY(event) : getTouchXY(event);
     const sourceEvent = shouldPreventQueue.current.filter(
-      (e) => e.name === event.type && (e.target === event.target || event.target === e.shadowParent) && deltaCompare(e.delta, delta)
+      (e) =>
+        e.name === event.type &&
+        (e.target === event.target || event.target === e.shadowParent) &&
+        deltaCompare(e.delta, delta)
     )[0];
 
     // self event, and should be canceled
@@ -200,12 +205,15 @@ export function RemoveScrollSideCar(props: IRemoveScrollEffectProps) {
 
 function getOutermostShadowParent(node: Node | null): HTMLElement | null {
   let shadowParent: HTMLElement | null = null;
+
   while (node !== null) {
     if (node instanceof ShadowRoot) {
       shadowParent = node.host as HTMLElement;
       node = node.host;
     }
+
     node = node.parentNode;
   }
-  return shadowParent
+
+  return shadowParent;
 }

--- a/src/UI.tsx
+++ b/src/UI.tsx
@@ -7,7 +7,6 @@ import { effectCar } from './medium';
 import {
   IRemoveScrollEffectProps,
   RemoveScrollEffectCallbacks,
-  IRemoveScrollUIProps,
   RemoveScrollUIType,
   IRemoveScrollSelfProps,
 } from './types';
@@ -21,7 +20,7 @@ const nothing = () => {
 /**
  * Removes scrollbar from the page and contain the scroll within the Lock
  */
-const RemoveScroll: RemoveScrollUIType = React.forwardRef<HTMLElement, IRemoveScrollUIProps>((props, parentRef) => {
+const RemoveScroll: RemoveScrollUIType = ({ ref: parentRef, ...props }) => {
   const ref = React.useRef<HTMLElement>(null);
 
   const [callbacks, setCallbacks] = React.useState<RemoveScrollEffectCallbacks>({
@@ -34,12 +33,12 @@ const RemoveScroll: RemoveScrollUIType = React.forwardRef<HTMLElement, IRemoveSc
     forwardProps,
     children,
     className,
-    removeScrollBar,
-    enabled,
+    removeScrollBar = true,
+    enabled = true,
     shards,
     sideCar,
     noIsolation,
-    inert,
+    inert = false,
     allowPinchZoom,
     as: Container = 'div',
     gapMode,
@@ -48,11 +47,12 @@ const RemoveScroll: RemoveScrollUIType = React.forwardRef<HTMLElement, IRemoveSc
 
   const SideCar: SideCarComponent<IRemoveScrollEffectProps> = sideCar;
 
-  const containerRef = useMergeRefs<any>([ref, parentRef as React.MutableRefObject<HTMLElement>]);
+  const containerRef = useMergeRefs<any>([ref, parentRef as React.RefObject<HTMLElement>]);
 
   const containerProps = {
     ...rest,
     ...callbacks,
+    ref: containerRef,
   };
 
   return (
@@ -71,23 +71,14 @@ const RemoveScroll: RemoveScrollUIType = React.forwardRef<HTMLElement, IRemoveSc
         />
       )}
       {forwardProps ? (
-        React.cloneElement(React.Children.only(children as React.ReactElement), {
-          ...containerProps,
-          ref: containerRef,
-        })
+        React.cloneElement(React.Children.only(children as React.ReactElement), containerProps)
       ) : (
-        <Container {...containerProps} className={className} ref={containerRef}>
+        <Container {...containerProps} className={className}>
           {children}
         </Container>
       )}
     </React.Fragment>
   );
-}) as any;
-
-RemoveScroll.defaultProps = {
-  enabled: true,
-  removeScrollBar: true,
-  inert: false,
 };
 
 RemoveScroll.classNames = {

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { Ref, RefObject } from 'react';
-import { ForwardRefExoticComponent } from 'react';
+import { Ref, RefObject, FunctionComponent } from 'react';
 import { RefAttributes } from 'react';
 
 export type Axis = 'v' | 'h';
@@ -99,7 +98,7 @@ export interface IRemoveScrollEffectProps {
 
   shards?: Array<React.RefObject<any> | HTMLElement>;
 
-  lockRef: RefObject<HTMLElement>;
+  lockRef: RefObject<HTMLElement | null>;
   gapMode?: GapMode;
 
   setCallbacks(cb: RemoveScrollEffectCallbacks): void;
@@ -112,7 +111,7 @@ interface WithClassNames {
   };
 }
 
-type RefForwarded<T> = ForwardRefExoticComponent<T & RefAttributes<HTMLElement>> & WithClassNames;
+type RefForwarded<T> = FunctionComponent<T & RefAttributes<HTMLElement>> & WithClassNames;
 
 export type RemoveScrollType = RefForwarded<IRemoveScrollProps>;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2666,11 +2666,6 @@
   resolved "https://registry.yarnpkg.com/@types/pretty-hrtime/-/pretty-hrtime-1.0.1.tgz#72a26101dc567b0d68fd956cf42314556e42d601"
   integrity sha512-VjID5MJb1eGKthz2qUerWT8+R4b9N+CHvGCzg9fn4kWZgaF9AhdYikQio3R7wV8YY1NsQKPaCwKz1Yff+aHNUQ==
 
-"@types/prop-types@*":
-  version "15.7.5"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
-  integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
-
 "@types/q@^1.5.1":
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.5.tgz#75a2a8e7d8ab4b230414505d92335d1dcb53a6df"
@@ -2695,19 +2690,12 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16", "@types/react@^16.9.22", "@types/react@^18.0.0":
-  version "18.0.5"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.5.tgz#1a4d4b705ae6af5aed369dec22800b20f89f5301"
-  integrity sha512-UPxNGInDCIKlfqBrm8LDXYWNfLHwIdisWcsH5GpMyGjhEDLFgTtlRBaoWuCua9HcyuE0rMkmAeZ3FXV1pYLIYQ==
+"@types/react@*", "@types/react@^16", "@types/react@^16.9.22", "@types/react@^18.0.0 || ^19.0.0":
+  version "19.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.0.1.tgz#a000d5b78f473732a08cecbead0f3751e550b3df"
+  integrity sha512-YW6614BDhqbpR5KtUYzTA+zlA7nayzJRA9ljz9CQoxthR0sDisYZLuvSMsil36t4EH/uAt8T52Xb4sVw17G+SQ==
   dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
     csstype "^3.0.2"
-
-"@types/scheduler@*":
-  version "0.16.2"
-  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
-  integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
 "@types/source-list-map@*":
   version "0.1.2"


### PR DESCRIPTION
This pr upgrades all types to react 19 and removes `defaultProps` and `forwardRef`

Right now it is broken because of the `use-sidecar` types - background is that the `JSX` types were moved to `React.JSX`

```
node_modules/use-sidecar/dist/es5/renderProp.d.ts:7:189 - error TS2503: Cannot find namespace 'JSX'.

7 export declare function renderCar<T extends any[], K, C = RenderPropComponent<T, K & Partial<SideCarHOC>>>(WrappedComponent: C, defaults: (props: K) => T): (props: CombinedProps<T, K>) => JSX.Element;
```