### PR TITLE
Bump use-callback-ref to 1.3.2 for React 19 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react-remove-scroll-bar": "^2.3.7",
     "react-style-singleton": "^2.2.1",
     "tslib": "^2.1.0",
-    "use-callback-ref": "^1.3.0",
+    "use-callback-ref": "^1.3.2",
     "use-sidecar": "^1.1.2"
   },
   "sideEffects": [


### PR DESCRIPTION
Bump use-callback-ref dependency from `1.3.0` to `1.3.2` to resolve React 19 peer dependency conflict.