### PR TITLE
fix: handle Shift + scroll as horizontal scroll

### DIFF
--- a/src/SideEffect.tsx
+++ b/src/SideEffect.tsx
@@ -60,8 +60,14 @@ export function RemoveScrollSideCar(props: IRemoveScrollEffectProps) {
 
     const touch = getTouchXY(event);
     const touchStart = touchStartRef.current;
-    const deltaX = 'deltaX' in event ? event.deltaX : touchStart[0] - touch[0];
-    const deltaY = 'deltaY' in event ? event.deltaY : touchStart[1] - touch[1];
+    let deltaX = 'deltaX' in event ? event.deltaX : touchStart[0] - touch[0];
+    let deltaY = 'deltaY' in event ? event.deltaY : touchStart[1] - touch[1];
+
+    // If Shift is pressed, interpret vertical scroll as horizontal scroll
+    if (event.shiftKey) {
+      deltaX = event.deltaY;
+      deltaY = 0;
+    }
 
     let currentAxis: Axis | undefined;
     const target: HTMLElement = event.target as any;


### PR DESCRIPTION
I use the ShadCN Dialog component and noticed an issue where Shift + Scroll (horizontal scroll) was incorrectly treated as vertical. This fixes the behavior now Shift scroll works as expected. (I’m a keyboard extremist :D)