### PR TITLE
fix: not prevent drag text in touch move

### DIFF
--- a/src/SideEffect.tsx
+++ b/src/SideEffect.tsx
@@ -73,6 +73,15 @@ export function RemoveScrollSideCar(props: IRemoveScrollEffectProps) {
       return false;
     }
 
+    // allow drag selection (iOS); check if selection's anchorNode is the same as target or contains target
+    const selection = document.getSelection();
+    const anchorNode = selection && selection.anchorNode;
+    const isTouchingSelection = anchorNode ? anchorNode.contains(target) : false;
+
+    if (isTouchingSelection) {
+      return false;
+    }
+
     let canBeScrolledInMainDirection = locationCouldBeScrolled(moveDirection, target);
 
     if (!canBeScrolledInMainDirection) {

--- a/src/SideEffect.tsx
+++ b/src/SideEffect.tsx
@@ -74,9 +74,9 @@ export function RemoveScrollSideCar(props: IRemoveScrollEffectProps) {
     }
 
     // allow drag selection (iOS); check if selection's anchorNode is the same as target or contains target
-    const selection = document.getSelection();
+    const selection = window.getSelection();
     const anchorNode = selection && selection.anchorNode;
-    const isTouchingSelection = anchorNode ? anchorNode.contains(target) : false;
+    const isTouchingSelection = anchorNode ? anchorNode === target || anchorNode.contains(target) : false;
 
     if (isTouchingSelection) {
       return false;


### PR DESCRIPTION
fixes: https://github.com/theKashey/react-remove-scroll/issues/130

only happens in iPhone, when trying to move caret in an input it's blocking the movement because it triggers `touchmove`, the same is not triggered for Android devices or Chrome dev tools. 

tried to add a robust solution to only check for elements in the _shards_, but it could be even simpler if move the logic to the `shouldPrevent` and check if `!!window.getSelection().anchorNode`.

let me know if you need help to simulate or any issues.