### PR TITLE
fix: handle reverse flex-direction when computing available scroll

### DIFF
--- a/src/handleScroll.ts
+++ b/src/handleScroll.ts
@@ -75,6 +75,16 @@ const getDirectionFactor = (axis: Axis, direction: string | null) =>
    */
   axis === 'h' && direction === 'rtl' ? -1 : 1;
 
+const elementIsReverseScrolled = (node: Element): boolean => {
+  if (!(node instanceof Element)) {
+    return false;
+  }
+
+  const styles = window.getComputedStyle(node);
+
+  return styles.flexDirection === 'column-reverse' || styles.flexDirection === 'row-reverse';
+};
+
 export const handleScroll = (
   axis: Axis,
   endTarget: HTMLElement,
@@ -106,8 +116,14 @@ export const handleScroll = (
 
     if (position || elementScroll) {
       if (elementCouldBeScrolled(axis, target)) {
-        availableScroll += elementScroll;
-        availableScrollTop += position;
+        if (elementIsReverseScrolled(target)) {
+          // For column-reverse/row-reverse, swap the available scroll calculations
+          availableScroll += position;
+          availableScrollTop += elementScroll;
+        } else {
+          availableScroll += elementScroll;
+          availableScrollTop += position;
+        }
       }
     }
 


### PR DESCRIPTION
This PR adds elementIsReverseScrolled and uses it to swap how available scroll is accumulated for elements with flex-direction: column-reverse or row-reverse, ensuring overscroll detection is correct for reversed flex layouts.

Fixes #148